### PR TITLE
Add Oracle Event Management with Secure Oracle Update and Event Triggering Logic

### DIFF
--- a/oracle-integration.clar
+++ b/oracle-integration.clar
@@ -1,0 +1,13 @@
+(define-data-var oracle principal 'SP3XG3Z0XQX0QX0QX0QX0QX0QX0QX0QX0QX0Q)
+
+(define-public (set-oracle (new-oracle principal))
+  (begin
+    (asserts! (is-eq tx-sender 'SZ2JCWQ0X0KX0X0X0X0X0X0X0X0X0X0X0X0X0X) "Unauthorized")
+    (var-set oracle new-oracle)
+    (ok "Oracle updated")))
+
+(define-public (oracle-trigger-event)
+  (begin
+    (asserts! (is-eq tx-sender (var-get oracle)) "Unauthorized oracle")
+    (var-set event-occurred true)
+    (ok "Event triggered by oracle")))


### PR DESCRIPTION
This pull request introduces an Oracle Event Management system, allowing an authorized oracle to trigger events on-chain and allowing for secure updates of the oracle address. The contract enables the following:

Key Features:

Set Oracle:
A function that allows the current oracle (authorized address) to update the oracle address. This can only be done by a specific, predefined address `('SZ2JCWQ0X0KX0X0X0X0X0X0X0X0X0X0X0X0X0X)`. This ensures that only an authorized entity can update the oracle.

Trigger Event:
The oracle-trigger-event function allows the current oracle to trigger an event (set event-occurred to true) on-chain, ensuring that only the designated oracle can trigger the event. Unauthorized users are prevented from triggering the event.

Secure Oracle Update:
Only the authorized entity can update the oracle, ensuring security and trustworthiness in the oracle's identity.

Use Cases:

This system can be integrated into decentralized applications (dApps) where an oracle is required to trigger on-chain events or fetch data from external sources in a secure, trustless manner.
Examples of use cases include triggering external smart contract actions based on off-chain data, such as price feeds, weather data, or any event-based data.
Files Added:

oracle-integration.clar